### PR TITLE
Support server systems

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714679908,
-        "narHash": "sha256-KzcXzDvDJjX34en8f3Zimm396x6idbt+cu4tWDVS2FI=",
+        "lastModified": 1716711219,
+        "narHash": "sha256-TnZETiQPXbyT5mdCHMOyrJnx2+BwroMBRrguciz1vEo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9036fe9ef8e15a819fa76f47a8b1f287903fb848",
+        "rev": "05e6ba83eb3585ce0aff7b41e4bd0e317d05ad4a",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714635257,
-        "narHash": "sha256-4cPymbty65RvF1DWQfc+Bc8B233A1BWxJnNULJKQ1EY=",
+        "lastModified": 1716509168,
+        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63c3a29ca82437c87573e4c6919b09a24ea61b0f",
+        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
         "type": "github"
       },
       "original": {
@@ -53,11 +53,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1713638189,
-        "narHash": "sha256-q7APLfB6FmmSMI1Su5ihW9IwntBsk2hWNXh8XtSdSIk=",
+        "lastModified": 1716655032,
+        "narHash": "sha256-kQ25DAiCGigsNR/Quxm3v+JGXAEXZ8I7RAF4U94bGzE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "74574c38577914733b4f7a775dd77d24245081dd",
+        "rev": "59a450646ec8ee0397f5fa54a08573e8240eb91f",
         "type": "github"
       },
       "original": {
@@ -83,11 +83,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713892811,
-        "narHash": "sha256-uIGmA2xq41vVFETCF1WW4fFWFT2tqBln+aXnWrvjGRE=",
+        "lastModified": 1716692524,
+        "narHash": "sha256-sALodaA7Zkp/JD6ehgwc0UCBrSBfB4cX66uFGTsqeFU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f1b0adc27265274e3b0c9b872a8f476a098679bd",
+        "rev": "962797a8d7f15ed7033031731d0bb77244839960",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,8 @@
 
     nixosConfigurations.Archy = nixosSystem nixpkgs attrs "archy";
 
+    nixosConfigurations.Nixxy = nixosSystem nixpkgs attrs "nixxy";
+
     formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixpkgs-fmt;
   };
 }

--- a/modules/impermanence/default.nix
+++ b/modules/impermanence/default.nix
@@ -55,9 +55,9 @@ in
     Defaults lecture = never
   '';
 
-  home-manager.users.sherex = { pkgs, ... }: {
+  #home-manager.users.sherex = { pkgs, ... }: {
     # TODO: Use home-manager for user file persistance?
-  };
+  #};
 
   # Source (but quite modified):
   # https://mt-caret.github.io/blog/posts/2020-06-29-optin-state.html#darling-erasure

--- a/modules/vpn/default.nix
+++ b/modules/vpn/default.nix
@@ -1,0 +1,12 @@
+{ config, pkgs, lib, home-manager, ... }:
+
+{
+  services.mullvad-vpn.enable = true;
+
+  environment.persistence."/persistent/safe" = {
+    directories = [
+      "/etc/mullvad-vpn"
+    ];
+  };
+}
+

--- a/sherex-server.nix
+++ b/sherex-server.nix
@@ -1,0 +1,33 @@
+{ config, pkgs, lib, home-manager, ... }:
+
+{
+  imports = [
+    home-manager.nixosModule
+    ./modules/bash
+    ./modules/neovim
+    ./modules/git
+  ];
+
+  # Install packages to /etc/profiles instead of ~/.nix-profile
+  home-manager.useUserPackages = true;
+  # Make home-manager use the global pkgs option
+  home-manager.useGlobalPkgs = true;
+
+  users.users.sherex = {
+    isNormalUser = true;
+    extraGroups = [
+      config.users.groups.wheel.name
+      config.users.groups.nix-allowed.name
+    ];
+    hashedPasswordFile = "/persistent/safe/sherex-password-hash";
+  };
+  home-manager.users.sherex = { pkgs, ... }: {
+    home.stateVersion = "22.11";
+    home.packages = with pkgs; [
+      unar
+      numbat
+      devbox
+    ];
+    programs.home-manager.enable = true;
+  };
+}

--- a/systems/common-server.nix
+++ b/systems/common-server.nix
@@ -1,0 +1,70 @@
+{ config, pkgs, ... }:
+
+{
+  imports = [
+    ../modules/swap
+    ../sherex-server.nix
+    ../modules/impermanence
+    #../modules/sops
+    #../modules/borg
+    ../modules/sshd
+  ];
+
+  #boot.loader.efi = {
+  #  canTouchEfiVariables = true;
+  #  efiSysMountPoint = config.fileSystems."/boot".mountPoint;
+  #};
+  boot.loader.grub = {
+    enable = true;
+    efiSupport = false;
+    devices = [ "nodev" ];
+    default = "saved";
+  };
+
+  time.timeZone = "Europe/Oslo";
+
+  i18n.defaultLocale = "en_US.UTF-8";
+  console = {
+    font = "Lat2-Terminus16";
+    keyMap = "no-latin1";
+  };
+
+  users.groups = {
+    nix-trusted = {};
+    nix-allowed = {};
+  };
+
+  # Nix Settings
+  nix.settings = {
+    experimental-features = [ "nix-command" "flakes" ];
+    use-xdg-base-directories = true;
+    trusted-users = [ "@nix-trusted" ];
+    allowed-users = [ "@nix-allowed" ];
+  };
+  nixpkgs.config.allowUnfree = true;
+
+  # Enable sound.
+  sound.enable = false;
+  # hardware.pulseaudio.enable = true;
+
+  # List packages installed in system profile. To search, run:
+  # $ nix search wget
+  environment.systemPackages = with pkgs; [
+    vim
+    neovim
+    wget
+    powertop
+    fakeroot
+    killall
+  ];
+
+  # Some programs need SUID wrappers, can be configured further or are
+  # started in user sessions.
+  # programs.mtr.enable = true;
+  # programs.gnupg.agent = {
+  #   enable = true;
+  #   enableSSHSupport = true;
+  # };
+}
+
+

--- a/systems/common.nix
+++ b/systems/common.nix
@@ -9,6 +9,7 @@
     ../modules/sops
     ../modules/borg
     ../modules/sshd
+    ../modules/vpn
   ];
 
   boot.loader.efi = {

--- a/systems/nixxy/configuration.nix
+++ b/systems/nixxy/configuration.nix
@@ -1,0 +1,24 @@
+{ config, pkgs, ... }:
+
+{
+  imports = [
+    ./hardware.nix
+    ../common-server.nix
+  ];
+
+  networking.hostName = "Nixxy";
+
+  networking.wireless.enable = false;
+
+  # Enable CUPS to print documents.
+  # services.printing.enable = true;
+
+  # This value determines the NixOS release from which the default
+  # settings for stateful data, like file locations and database versions
+  # on your system were taken. It‘s perfectly fine and recommended to leave
+  # this value at the release version of the first install of this system.
+  # Before changing this value read the documentation for this option
+  # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
+  system.stateVersion = "22.11"; # Did you read the comment?
+}
+

--- a/systems/nixxy/hardware.nix
+++ b/systems/nixxy/hardware.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, modulesPath, ... }:
+
+{
+  imports = [
+    (modulesPath + "/installer/scan/not-detected.nix")
+  ];
+
+  boot.initrd.availableKernelModules = [ "ata_piix" "uhci_hcd" "virtio_pci" "virtio_scsi" "sd_mod" ];
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ "kvm-intel" ];
+  boot.extraModulePackages = [ ];
+
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixxy";
+    fsType = "btrfs";
+    options = [ "subvol=subvolumes/tmp" "compress=zstd:1" "noatime" ];
+    neededForBoot = true;
+  };
+
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-label/nixboot";
+    fsType = "vfat";
+  };
+
+ fileSystems."/persistent/unsafe" = {
+    device = "/dev/disk/by-label/nixxy";
+    fsType = "btrfs";
+    options = [ "subvol=subvolumes/unsafe" "compress=zstd:1" "noatime" ];
+    neededForBoot = true;
+  };
+
+  fileSystems."/persistent/safe" = {
+    device = "/dev/disk/by-label/nixxy";
+    fsType = "btrfs";
+    options = [ "subvol=subvolumes/safe" "compress=zstd:1" "noatime" ];
+    neededForBoot = true;
+  };
+
+  fileSystems."/nix" = {
+    device = "/persistent/unsafe/nix";
+    fsType = "none";
+    options = [ "bind" ];
+    neededForBoot = true;
+  };
+
+  swapDevices = [ ];
+
+  # Enables DHCP on each ethernet and wireless interface. In case of scripted networking
+  # (the default) this is the recommended approach. When using systemd-networkd it's
+  # still possible to use this option, but it's recommended to use it in conjunction
+  # with explicit per-interface declarations with `networking.interfaces.<interface>.useDHCP`.
+  networking.useDHCP = lib.mkDefault true;
+  # networking.interfaces.enp0s20f0u3c2.useDHCP = lib.mkDefault true;
+  # networking.interfaces.enp0s31f6.useDHCP = lib.mkDefault true;
+  # networking.interfaces.wlp1s0.useDHCP = lib.mkDefault true;
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+}


### PR DESCRIPTION
A work in progress branch to add support for server systems.
The goal is to generalize the existing module just enough so they can be used both on desktops and servers.
This seems like a good oppurtunity to start using the mkOption function.

## TODO
1. Get a working server with the existing config with as few changes as possible (ie. copipasta all over the place)
  - [ ] Create Nixxy system config
  - [ ] Create Sherex config for server
  - [ ] Do further changes to make the server stable
2. Generalize the duplicated modules by using the `mkOption` function
3. Look into integrating `disko` with the current config
4. Look into making `nixos-anywhere` able to automatically bootstrap the server